### PR TITLE
Load cufft dll in Windows (CUDA 6.5, 7.0, 7.5 only)

### DIFF
--- a/src/libcufft.jl
+++ b/src/libcufft.jl
@@ -1,10 +1,22 @@
 module LibCUFFT
 using Compat
 
+import Base.Sys: WORD_SIZE
+
 include("cufft_h.jl")
 import CUDArt.rt.cudaStream_t
 
-const libcufft = Libdl.find_library(["libcufft", "cufft"], ["/usr/local/cuda"])
+@windows? (
+begin
+    const libcufft = Libdl.find_library([string("cufft", WORD_SIZE, "_75"),
+      string("cufft", WORD_SIZE, "_70"), string("cufft", WORD_SIZE, "_65")],
+      [joinpath(ENV["CUDA_PATH"], "bin")])
+end
+: # linux or mac
+begin
+    const libcufft = Libdl.find_library(["libcufft", "cufft"], ["/usr/lib", "/usr/local/cuda"])
+end)
+
 isempty(libcufft) && error("Cannot load libcufft")
 
 function checkerror(code::cufftResult)


### PR DESCRIPTION
As same as CUDArt.ji(https://github.com/JuliaGPU/CUDArt.jl/blob/master/src/CUDArt.jl#L31), I made a patch to be able to load CUFFT library from windows. It passes tests on Windows 10 64bit and CUDA 7.5.
