### PR TITLE
fixes for 0.6 and new CUFFT

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.4
 CUDArt
 Compat

--- a/src/CUFFT.jl
+++ b/src/CUFFT.jl
@@ -50,12 +50,12 @@ RCfree{T<:AbstractFloat}(R::CudaPitchedArray{T}, C::CudaPitchedArray{Complex{T}}
 function plan_size(dest, src)
     nd = ndims(dest)
     ndims(src) == nd || throw(DimensionMismatch())
-    sz = Array(Cint, nd)
+    sz = Vector{Cint}(nd)
     for i = 2:nd
         if size(dest,i) != size(src,i)
             throw(DimensionMismatch())
         end
-        sz[i] = size(dest,i)
+        sz[i] = size(dest, i)
     end
     local plantype
     if eltype(dest) == eltype(src)
@@ -83,7 +83,7 @@ function plan(dest::AbstractCudaArray, src::AbstractCudaArray; compat::Symbol = 
     plantype = plan_dict[(eltype(src),eltype(dest))]
     lib.cufftPlanMany(p, ndims(dest), sz, inembed, 1, 1, onembed, 1, 1, plantype, 1)
     pl = Plan{eltype(src),eltype(dest),ndims(dest)}(p[1])
-    compatibility(pl, compat)
+    #compatibility(pl, compat)
     tie(pl, stream)
     (dest,src,forward) -> exec!(pl, src, dest, forward)
 end
@@ -105,7 +105,7 @@ exec!(p::Plan{Complex128,Float64}, input, output, forward::Bool = true) =
 
 version() = (ret = Cint[0]; lib.cufftGetVersion(ret); ret[1])
 
-modedict = @compat Dict(
+modedict = Dict(
     :native     => lib.CUFFT_COMPATIBILITY_NATIVE,
     :padding    => lib.CUFFT_COMPATIBILITY_FFTW_PADDING,
     :asymmetric => lib.CUFFT_COMPATIBILITY_FFTW_ASYMMETRIC,

--- a/src/cufft_h.jl
+++ b/src/cufft_h.jl
@@ -1,28 +1,36 @@
-# CUFFT API function return values 
-typealias cufftResult Cint
-const CUFFT_SUCCESS        = 0x0
-const CUFFT_INVALID_PLAN   = 0x1
-const CUFFT_ALLOC_FAILED   = 0x2
-const CUFFT_INVALID_TYPE   = 0x3
-const CUFFT_INVALID_VALUE  = 0x4
-const CUFFT_INTERNAL_ERROR = 0x5
-const CUFFT_EXEC_FAILED    = 0x6
-const CUFFT_SETUP_FAILED   = 0x7
-const CUFFT_INVALID_SIZE   = 0x8
-const CUFFT_UNALIGNED_DATA = 0x9
-    
-typealias cufftReal Float32
-typealias cufftDoubleReal Float64
+# CUFFT API function return values
+@enum(cufftResult,
+    CUFFT_SUCCESS        = 0,  #  The cuFFT operation was successful
+    CUFFT_INVALID_PLAN   = 1,  #  cuFFT was passed an invalid plan handle
+    CUFFT_ALLOC_FAILED   = 2,  #  cuFFT failed to allocate GPU or CPU memory
+    CUFFT_INVALID_TYPE   = 3,  #  No longer used
+    CUFFT_INVALID_VALUE  = 4,  #  User specified an invalid pointer or parameter
+    CUFFT_INTERNAL_ERROR = 5,  #  Driver or internal cuFFT library error
+    CUFFT_EXEC_FAILED    = 6,  #  Failed to execute an FFT on the GPU
+    CUFFT_SETUP_FAILED   = 7,  #  The cuFFT library failed to initialize
+    CUFFT_INVALID_SIZE   = 8,  #  User specified an invalid transform size
+    CUFFT_UNALIGNED_DATA = 9,  #  No longer used
+    CUFFT_INCOMPLETE_PARAMETER_LIST = 10, #  Missing parameters in call
+    CUFFT_INVALID_DEVICE = 11, #  Execution of a plan was on different GPU than plan creation
+    CUFFT_PARSE_ERROR    = 12, #  Internal plan database error
+    CUFFT_NO_WORKSPACE   = 13,  #  No workspace has been provided prior to plan execution
+    CUFFT_NOT_IMPLEMENTED = 14, # Function does not implement functionality for parameters given.
+    CUFFT_LICENSE_ERROR  = 15, # Used in previous versions.
+    CUFFT_NOT_SUPPORTED  = 16  # Operation is not supported for parameters given.
+)
 
-typealias cufftComplex Complex64
-typealias cufftDoubleComplex Complex128
+const cufftReal = Float32
+const cufftDoubleReal = Float64
 
-# CUFFT transform directions 
+const cufftComplex = Complex64
+const cufftDoubleComplex = Complex128
+
+# CUFFT transform directions
 const CUFFT_FORWARD = -1 # Forward FFT
 const CUFFT_INVERSE =  1 # Inverse FFT
 
-# CUFFT supports the following transform types 
-typealias cufftType Cint
+# CUFFT supports the following transform types
+const cufftType = Cint
 const CUFFT_R2C = 0x2a     # Real to Complex
 const CUFFT_C2R = 0x2c     # Complex to Real
 const CUFFT_C2C = 0x29     # Complex to Complex
@@ -30,10 +38,10 @@ const CUFFT_D2Z = 0x6a     # Double to Double-Complex
 const CUFFT_Z2D = 0x6c     # Double-Complex to Double
 const CUFFT_Z2Z = 0x69     # Double-Complex to Double-Complex
 
-typealias cufftCompatibility Cint
+const cufftCompatibility = Cint
 const   CUFFT_COMPATIBILITY_NATIVE          = 0x00
 const   CUFFT_COMPATIBILITY_FFTW_PADDING    = 0x01
 const   CUFFT_COMPATIBILITY_FFTW_ASYMMETRIC = 0x02
 const   CUFFT_COMPATIBILITY_FFTW_ALL        = 0x03
 
-typealias cufftHandle Cint
+const cufftHandle = Cint

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,14 +17,14 @@ CUDArt.devices(dev->CUDArt.capability(dev)[1] >= 2, nmax=1) do devlist
     pl!(gfft, g, true)
     afftg = CUDArt.to_host(gfft)
     afft = rfft(a)
-    @test_approx_eq afftg afft
+    @test afftg ≈ afft
     # Perform the IFFT
     pli! = CUFFT.plan(g, gfft)
     pli!(g, gfft, false)
     # Move back to host and compare
     a2 = CUDArt.to_host(g)
-    @test_approx_eq a a2/n
-    
+    @test a ≈ a2/n
+
     # 2D transform with CudaArrays
     A = rand(7,6)
     G = CUDArt.CudaArray(A)
@@ -33,11 +33,11 @@ CUDArt.devices(dev->CUDArt.capability(dev)[1] >= 2, nmax=1) do devlist
     pl!(GFFT, G, true)
     AFFTG = CUDArt.to_host(GFFT)
     AFFT = rfft(A)
-    @test_approx_eq AFFTG AFFT
+    @test AFFTG ≈ AFFT
     pli! = CUFFT.plan(G,GFFT)
     pli!(G, GFFT, false)
     A2 = CUDArt.to_host(G)
-    @test_approx_eq A A2/length(A)
+    @test A ≈ A2/length(A)
 
     # 2D transform with CudaPitchedArrays
     A = rand(8,3)
@@ -47,11 +47,11 @@ CUDArt.devices(dev->CUDArt.capability(dev)[1] >= 2, nmax=1) do devlist
     pl!(GFFT, G, true)
     AFFTG = CUDArt.to_host(GFFT)
     AFFT = rfft(A)
-    @test_approx_eq AFFTG AFFT
+    @test AFFTG ≈ AFFT
     pli! = CUFFT.plan(G,GFFT)
     pli!(G, GFFT, false)
     A2 = CUDArt.to_host(G)
-    @test_approx_eq A A2/length(A)
+    @test A ≈ A2/length(A)
 
     # 2D in-place transform
     A = rand(8,3)
@@ -60,12 +60,12 @@ CUDArt.devices(dev->CUDArt.capability(dev)[1] >= 2, nmax=1) do devlist
     pl!(GFFT, G, true)
     AFFTG = CUDArt.to_host(GFFT)
     AFFT = rfft(A)
-    @test_approx_eq AFFTG AFFT
+    @test AFFTG ≈ AFFT
     pli! = CUFFT.plan(G,GFFT)
     pli!(G, GFFT, false)
     A2 = CUDArt.to_host(G)
-    @test_approx_eq A A2/length(A)
-    
+    @test A ≈ A2/length(A)
+
     # 3D transform using CudaArray
     NX, NY, NZ = 38, 69, 108
     A = randn(NX, NY, NZ)
@@ -75,11 +75,11 @@ CUDArt.devices(dev->CUDArt.capability(dev)[1] >= 2, nmax=1) do devlist
     pl!(GFFT, G, true)
     AFFTG = CUDArt.to_host(GFFT)
     AFFT = rfft(A)
-    @test_approx_eq AFFTG AFFT
+    @test AFFTG ≈ AFFT
     pli! = CUFFT.plan(G, GFFT)
     pli!(G, GFFT, false)
     A2 = CUDArt.to_host(G)
-    @test_approx_eq A A2/length(A)
+    @test A ≈ A2/length(A)
 
     # ... and with CudaPitchedArrays
     G = CUDArt.CudaPitchedArray(A)
@@ -88,9 +88,9 @@ CUDArt.devices(dev->CUDArt.capability(dev)[1] >= 2, nmax=1) do devlist
     pl!(GFFT, G, true)
     AFFTG = CUDArt.to_host(GFFT)
     AFFT = rfft(A)
-    @test_approx_eq AFFTG AFFT
+    @test AFFTG ≈ AFFT
     pli! = CUFFT.plan(G, GFFT)
     pli!(G, GFFT, false)
     A2 = CUDArt.to_host(G)
-    @test_approx_eq A A2/length(A)
+    @test A ≈ A2/length(A)
 end


### PR DESCRIPTION
removes depwarns + errors!

`compatibility` seems to be deprecated in the newest CUFFT version. I didn't find much information about it, but it seems it's simply not needed anymore?
Not test on 0.4/0.5 yet!