### PR TITLE
In CUDA 8.0 the native compatibility mode has been discon…

### DIFF
--- a/src/CUFFT.jl
+++ b/src/CUFFT.jl
@@ -73,7 +73,7 @@ end
 # Returns a function dofft!(dest, src, forward).
 # Unlike FFTW's plan, this does not destroy the inputs
 # TODO?: add dims
-function plan(dest::AbstractCudaArray, src::AbstractCudaArray; compat::Symbol = :native, stream=null_stream)
+function plan(dest::AbstractCudaArray, src::AbstractCudaArray; compat::Symbol = :padding, stream=null_stream)
     p = Cint[0]
     sz = plan_size(dest, src)
     inembed = reverse(Cint[size(src)...])


### PR DESCRIPTION
…tinued. Default to padding mode instead.  I'm not sure if this is the best default mode and am open to suggestions, but it seems that anything is better than defaulting to native mode.  More info here:

https://devtalk.nvidia.com/default/topic/896719/apparently-bug-in-cufft-of-cuda-7-5-with-deprecated-native-compatibility/