### PR TITLE
Fix loading error for libcufft

### DIFF
--- a/src/libcufft.jl
+++ b/src/libcufft.jl
@@ -11,7 +11,7 @@ if is_windows()
       string("cufft", WORD_SIZE, "_70"), string("cufft", WORD_SIZE, "_65")],
       [joinpath(ENV["CUDA_PATH"], "bin")])
 else
-    const libcufft = Libdl.find_library(["libcufft", "cufft"], ["/usr/lib", "/usr/local/cuda"])
+    const libcufft = Libdl.find_library(["libcufft", "cufft"], ["/usr/lib", "/usr/local/cuda", "/usr/local/cuda/lib64"])
 end
 
 isempty(libcufft) && error("Cannot load libcufft")


### PR DESCRIPTION
Command 'using CUFFT' met 'LoadError: Cannot load libdufft' because it cannot find 'libdufft' library in the specified path list. So this fix add "/usr/local/cuda/lib64" to the path list.